### PR TITLE
Implement survey launch endpoint and frontend widget

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+node_modules/
+*.db
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Mi Proyecto
+# Survey Launcher
+
+This project contains a FastAPI backend and a React frontend for uploading and launching surveys.
+
+## Development
+
+Use Docker Compose to start all services:
+
+```bash
+docker-compose up
+```
+
+The backend exposes `POST /launch` which accepts a JSON survey file and stores it in Postgres.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY ./app /app/app
+COPY survey.schema.json /app/survey.schema.json
+RUN pip install fastapi uvicorn[standard] sqlalchemy jsonschema
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,46 @@
+from fastapi import FastAPI, File, UploadFile, HTTPException
+from fastapi.responses import JSONResponse
+from jsonschema import validate, ValidationError
+import json
+import uuid
+import os
+from sqlalchemy import create_engine, Table, Column, MetaData, String, JSON
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+engine = create_engine(DATABASE_URL, future=True)
+metadata = MetaData()
+
+surveys_table = Table(
+    "surveys",
+    metadata,
+    Column("id", String, primary_key=True),
+    Column("data", JSON),
+)
+
+metadata.create_all(engine)
+
+app = FastAPI()
+
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "survey.schema.json")
+with open(SCHEMA_PATH) as f:
+    SURVEY_SCHEMA = json.load(f)
+
+@app.post("/launch")
+async def launch_survey(file: UploadFile = File(...)):
+    try:
+        content = await file.read()
+        data = json.loads(content)
+        validate(instance=data, schema=SURVEY_SCHEMA)
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    survey_id = str(uuid.uuid4())
+    token = str(uuid.uuid4())
+    link = f"/survey/{survey_id}?token={token}"
+
+    with engine.begin() as conn:
+        conn.execute(surveys_table.insert().values(id=survey_id, data=data))
+
+    return JSONResponse({"survey_id": survey_id, "link": link})

--- a/backend/app/tests/test_launch_endpoint.py
+++ b/backend/app/tests/test_launch_endpoint.py
@@ -1,0 +1,36 @@
+from fastapi.testclient import TestClient
+from pathlib import Path
+import json
+
+from backend.app.main import app
+
+client = TestClient(app)
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / 'survey.schema.json'
+
+with open(SCHEMA_PATH) as f:
+    VALID_SURVEY = json.load(f)
+
+
+def test_launch_success(tmp_path):
+    survey = {
+        "title": "Test",
+        "questions": [
+            {"id": "q1", "type": "text", "text": "Hello"}
+        ]
+    }
+    file = tmp_path / "survey.json"
+    file.write_text(json.dumps(survey))
+    with file.open('rb') as f:
+        response = client.post('/launch', files={'file': ('survey.json', f, 'application/json')})
+    assert response.status_code == 200
+    data = response.json()
+    assert 'survey_id' in data
+    assert 'link' in data
+
+def test_launch_invalid(tmp_path):
+    file = tmp_path / "bad.json"
+    file.write_text(json.dumps({"title": "Invalid"}))
+    with file.open('rb') as f:
+        response = client.post('/launch', files={'file': ('bad.json', f, 'application/json')})
+    assert response.status_code == 422

--- a/backend/app/tests/test_schema_validation.py
+++ b/backend/app/tests/test_schema_validation.py
@@ -1,0 +1,24 @@
+import json
+from jsonschema import validate, ValidationError
+from pathlib import Path
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / 'survey.schema.json'
+with open(SCHEMA_PATH) as f:
+    SCHEMA = json.load(f)
+
+def test_valid_survey():
+    data = {
+        "title": "Customer Feedback",
+        "questions": [
+            {"id": "q1", "type": "text", "text": "What do you think?"}
+        ]
+    }
+    validate(instance=data, schema=SCHEMA)
+
+def test_invalid_survey():
+    data = {"title": "Invalid"}
+    try:
+        validate(instance=data, schema=SCHEMA)
+        assert False, 'Should raise ValidationError'
+    except ValidationError:
+        pass

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  backend:
+    build: ./backend
+    volumes:
+      - ./survey.schema.json:/app/survey.schema.json
+    ports:
+      - '8000:8000'
+    environment:
+      - DATABASE_URL=postgresql+psycopg2://postgres:postgres@db:5432/postgres
+    depends_on:
+      - db
+  frontend:
+    build: ./frontend
+    ports:
+      - '5173:5173'
+    depends_on:
+      - backend
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - '5432:5432'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json vite.config.js tailwind.config.js postcss.config.js index.html /app/
+COPY src /app/src
+RUN npm install && npm run build
+CMD ["npx", "vite", "preview", "--host", "0.0.0.0", "--port", "5173"]

--- a/frontend/cypress.config.js
+++ b/frontend/cypress.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  e2e: {
+    baseUrl: 'http://localhost:5173',
+    supportFile: false
+  }
+}

--- a/frontend/cypress/e2e/launch.cy.js
+++ b/frontend/cypress/e2e/launch.cy.js
@@ -1,0 +1,17 @@
+describe('Survey upload', () => {
+  it('uploads valid survey', () => {
+    cy.visit('/')
+    const file = { fileContent: '{"title":"A","questions":[{"id":"q1","type":"text","text":"ok"}]}', fileName: 'survey.json', mimeType: 'application/json' }
+    cy.get('input[type=file]').selectFile(file)
+    cy.contains('Upload').click()
+    cy.contains('Link').should('exist')
+  })
+
+  it('shows error on invalid survey', () => {
+    cy.visit('/')
+    const file = { fileContent: '{"title":"bad"}', fileName: 'bad.json', mimeType: 'application/json' }
+    cy.get('input[type=file]').selectFile(file)
+    cy.contains('Upload').click()
+    cy.contains('error', { matchCase: false })
+  })
+})

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Survey Uploader</title>
+  <script type="module" src="/src/main.jsx"></script>
+</head>
+<body class="p-4">
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "cypress run"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.4.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "cypress": "^13.0.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,10 @@
+import SurveyUploader from './components/SurveyUploader'
+
+export default function App() {
+  return (
+    <div className="container mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Launch Survey</h1>
+      <SurveyUploader />
+    </div>
+  )
+}

--- a/frontend/src/components/SurveyUploader.jsx
+++ b/frontend/src/components/SurveyUploader.jsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+
+export default function SurveyUploader() {
+  const [error, setError] = useState(null)
+  const [link, setLink] = useState(null)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setError(null)
+    setLink(null)
+    const formData = new FormData(e.target)
+    try {
+      const res = await fetch('/launch', {
+        method: 'POST',
+        body: formData
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.detail)
+      }
+      const data = await res.json()
+      setLink(data.link)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input type="file" name="file" accept="application/json" required />
+      <button type="submit" className="px-4 py-2 bg-blue-500 text-white rounded">
+        Upload
+      </button>
+      {error && <p className="text-red-600">{error}</p>}
+      {link && (
+        <p>
+          Link: <a href={link} className="text-blue-600 underline">{link}</a>
+        </p>
+      )}
+    </form>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/launch': 'http://backend:8000'
+    }
+  }
+})

--- a/survey.schema.json
+++ b/survey.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Survey",
+  "type": "object",
+  "required": ["title", "questions"],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "questions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "type", "text"],
+        "properties": {
+          "id": {"type": "string"},
+          "type": {"type": "string", "enum": ["single_choice", "multiple_choice", "text"]},
+          "text": {"type": "string"},
+          "options": {
+            "type": "array",
+            "items": {"type": "string"}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add JSON schema for surveys
- implement FastAPI endpoint for launching surveys
- create React SurveyUploader component
- add Docker setup for backend, frontend, and Postgres
- include basic tests for schema and endpoint

## Testing
- `flake8` *(fails: command not found)*
- `pytest backend/app/tests` *(fails: missing dependencies)*
- `npx cypress run` *(fails: package download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68783bea62008329802e2714f4642ed5