### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - run: pip install -r backend/requirements.txt
+      - run: pytest backend/app/tests
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+        working-directory: frontend
+      - run: docker-compose up -d
+      - run: npx wait-on http://localhost:5173
+      - run: npm test
+        working-directory: frontend
+      - run: docker-compose down
+        if: always()


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run backend and frontend tests

## Testing
- `pytest backend/app/tests` *(fails: ModuleNotFoundError: fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_687843387b2483299ef438d40ad82f95