### PR TITLE
Fix Dockerfile paths for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3.12-slim
 WORKDIR /app
-COPY requirements.txt /app/requirements.txt
+COPY backend/requirements.txt /app/requirements.txt
 
-COPY ./app /app/app
+COPY backend/app /app/app
 COPY survey.schema.json /app/survey.schema.json
 RUN pip install -r requirements.txt
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- update backend Dockerfile to copy files from backend folder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: fastapi)*
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784b2b65088329b77064965d9205b2