### PR TITLE
Add streaming STT skeleton

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI, File, UploadFile, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
+from .stt_stream import router as stt_router
+
 from jsonschema import validate, ValidationError
 import json
 import uuid
@@ -19,6 +21,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.include_router(stt_router)
 
 # Locate ``survey.schema.json``. When running inside Docker ``__file__`` will
 # be ``/app/app/main.py`` while during development it may be

--- a/backend/app/stt_stream.py
+++ b/backend/app/stt_stream.py
@@ -1,0 +1,74 @@
+import os
+import io
+import uuid
+import importlib
+import sqlite3
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+DATABASE_URL = os.getenv("DATABASE_URL", ":memory:")
+engine = sqlite3.connect(DATABASE_URL, check_same_thread=False)
+engine.execute(
+    "CREATE TABLE IF NOT EXISTS turns (survey_id TEXT, token TEXT, question_id TEXT, role TEXT, audio_url TEXT, transcript TEXT, timestamp TEXT)"
+)
+
+router = APIRouter()
+
+MAX_CHUNK_BYTES = 64000  # approx 2s of 16kHz 16bit audio
+
+
+def get_supabase_client():
+    try:
+        supabase_mod = importlib.import_module("supabase")
+    except ModuleNotFoundError as e:  # pragma: no cover - handled in tests via mock
+        raise RuntimeError("supabase module not installed") from e
+    url = os.environ.get("SUPABASE_URL")
+    key = os.environ.get("SUPABASE_KEY")
+    return supabase_mod.create_client(url, key)
+
+
+def transcribe_audio(data: bytes):
+    try:
+        openai = importlib.import_module("openai")
+    except ModuleNotFoundError as e:  # pragma: no cover - handled in tests via mock
+        raise RuntimeError("openai module not installed") from e
+    openai.api_key = os.environ.get("OPENAI_API_KEY", "test")
+    file_obj = io.BytesIO(data)
+    file_obj.name = "audio.wav"
+    resp = openai.audio.transcriptions.create(model="whisper-1", file=file_obj)
+    text_out = getattr(resp, "text", "") if not isinstance(resp, dict) else resp.get("text", "")
+    confidence = getattr(resp, "confidence", 1.0) if not isinstance(resp, dict) else resp.get("confidence", 1.0)
+    return text_out, float(confidence)
+
+
+@router.websocket("/stt-stream")
+async def stt_stream(ws: WebSocket, survey_id: str, token: str, question_id: str, role: str):
+    await ws.accept()
+    supabase = get_supabase_client()
+    bucket = os.getenv("SUPABASE_BUCKET", "audio")
+
+    while True:
+        try:
+            data = await ws.receive_bytes()
+        except WebSocketDisconnect:
+            break
+
+        if len(data) > MAX_CHUNK_BYTES:
+            await ws.close(code=1003)
+            break
+
+        audio_name = f"{uuid.uuid4()}.wav"
+        supabase.storage.from_(bucket).upload(audio_name, data)
+        signed = supabase.storage.from_(bucket).create_signed_url(audio_name, 604800)
+        audio_url = signed["signedURL"] if isinstance(signed, dict) else signed
+
+        transcript, confidence = transcribe_audio(data)
+
+        cur = engine.cursor()
+        cur.execute(
+            "INSERT INTO turns (survey_id, token, question_id, role, audio_url, transcript, timestamp)"
+            " VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
+            (survey_id, token, question_id, role, audio_url, transcript),
+        )
+        engine.commit()
+
+        await ws.send_json({"transcript": transcript, "confidence": confidence})

--- a/backend/app/tests/test_stt_stream.py
+++ b/backend/app/tests/test_stt_stream.py
@@ -1,0 +1,48 @@
+import sqlite3
+from fastapi.testclient import TestClient
+from app.main import app
+from app import stt_stream
+
+client = TestClient(app)
+
+class DummyStorage:
+    def __init__(self):
+        self.uploaded = {}
+    def upload(self, name, data):
+        self.uploaded[name] = data
+    def create_signed_url(self, name, _):
+        return {"signedURL": f"http://example.com/{name}"}
+
+class DummyBucket:
+    def __init__(self):
+        self.uploaded = {}
+    def from_(self, bucket):
+        return self
+    def upload(self, name, data):
+        self.uploaded[name] = data
+    def create_signed_url(self, name, ttl):
+        return {"signedURL": f"http://example.com/{name}"}
+
+class DummySupabase:
+    def __init__(self):
+        self.storage = DummyBucket()
+
+
+def test_stt_stream_inserts_and_returns(tmp_path, monkeypatch):
+    # setup in-memory sqlite
+    stt_stream.engine = sqlite3.connect(':memory:', check_same_thread=False)
+    stt_stream.engine.execute("CREATE TABLE turns (survey_id TEXT, token TEXT, question_id TEXT, role TEXT, audio_url TEXT, transcript TEXT, timestamp TEXT)")
+
+    monkeypatch.setattr(stt_stream, 'get_supabase_client', lambda: DummySupabase())
+    monkeypatch.setattr(stt_stream, 'transcribe_audio', lambda data: ("hi", 0.9))
+
+    with client.websocket_connect("/stt-stream?survey_id=s1&token=t1&question_id=q1&role=user") as ws:
+        ws.send_bytes(b'abc')
+        data = ws.receive_json()
+    assert data['transcript'] == 'hi'
+    assert data['confidence'] == 0.9
+
+    cur = stt_stream.engine.cursor()
+    cur.execute("SELECT survey_id, token, question_id, role, transcript FROM turns")
+    row = cur.fetchone()
+    assert row == ('s1', 't1', 'q1', 'user', 'hi')

--- a/backend/migrations/001_create_turns.sql
+++ b/backend/migrations/001_create_turns.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS turns (
+    id SERIAL PRIMARY KEY,
+    survey_id UUID NOT NULL,
+    token UUID NOT NULL,
+    question_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    audio_url TEXT,
+    transcript TEXT,
+    timestamp TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,5 @@ httpx
 pytest
 psycopg2-binary
 python-multipart
+openai>=1.15.0
+supabase-py>=2.0.0

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -25,6 +25,43 @@ class FastAPI:
             return func
         return decorator
 
+    def websocket(self, path):
+        def decorator(func):
+            self.routes[("websocket", path)] = func
+            return func
+        return decorator
+
+    def include_router(self, router):
+        self.routes.update(router.routes)
+
+class APIRouter:
+    def __init__(self):
+        self.routes = {}
+    def websocket(self, path):
+        def decorator(func):
+            self.routes[("websocket", path)] = func
+            return func
+        return decorator
+
+class WebSocketDisconnect(Exception):
+    pass
+
+class WebSocket:
+    def __init__(self):
+        self._recv = []
+        self._send = []
+    async def accept(self):
+        pass
+    async def receive_bytes(self):
+        if not self._recv:
+            raise WebSocketDisconnect()
+        data = self._recv.pop(0)
+        if data is None:
+            raise WebSocketDisconnect()
+        return data
+    async def send_json(self, data):
+        self._send.append(data)
+
 from .responses import JSONResponse
 from .testclient import TestClient
 from .middleware import CORSMiddleware

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,15 @@
 import SurveyUploader from './components/SurveyUploader'
+import LiveTranscript from './components/LiveTranscript'
+import useSttStream from './hooks/useSttStream'
 
 export default function App() {
+  const stt = useSttStream({ surveyId: 'demo', token: 'demo', questionId: 'q1', role: 'user' })
+
   return (
-    <div className="container mx-auto">
+    <div className="container mx-auto space-y-4">
       <h1 className="text-2xl font-bold mb-4">Launch Survey</h1>
       <SurveyUploader />
+      <LiveTranscript transcript={stt.transcript} confirmed={stt.confirmed} />
     </div>
   )
 }

--- a/frontend/src/components/LiveTranscript.jsx
+++ b/frontend/src/components/LiveTranscript.jsx
@@ -1,0 +1,7 @@
+export default function LiveTranscript({ transcript, confirmed }) {
+  return (
+    <p className={confirmed ? 'text-green-600' : 'text-gray-800'}>
+      {transcript}
+    </p>
+  )
+}

--- a/frontend/src/hooks/useSttStream.js
+++ b/frontend/src/hooks/useSttStream.js
@@ -1,0 +1,34 @@
+import { useEffect, useRef, useState } from 'react'
+
+export default function useSttStream({ surveyId, token, questionId, role }) {
+  const [transcript, setTranscript] = useState('')
+  const [confidence, setConfidence] = useState(0)
+  const wsRef = useRef(null)
+
+  useEffect(() => {
+    const base = import.meta.env.VITE_API_URL || 'ws://localhost:8000'
+    const url = `${base.replace('http', 'ws')}/stt-stream?survey_id=${surveyId}&token=${token}&question_id=${questionId}&role=${role}`
+    const ws = new WebSocket(url)
+    wsRef.current = ws
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        setTranscript((t) => t + data.transcript)
+        setConfidence(data.confidence)
+      } catch {}
+    }
+
+    return () => ws.close()
+  }, [surveyId, token, questionId, role])
+
+  const sendChunk = (blob) => {
+    if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
+      wsRef.current.send(blob)
+    }
+  }
+
+  const confirmed = confidence >= 0.85
+
+  return { transcript, confidence, confirmed, sendChunk }
+}

--- a/scripts/load_test_script.py
+++ b/scripts/load_test_script.py
@@ -1,0 +1,23 @@
+import asyncio
+import statistics
+import time
+import websockets
+
+URL = 'ws://localhost:8000/stt-stream?survey_id=test&token=tok&question_id=q1&role=user'
+AUDIO_CHUNK = b'0' * 32000
+
+async def run_session(latencies):
+    async with websockets.connect(URL) as ws:
+        start = time.perf_counter()
+        await ws.send(AUDIO_CHUNK)
+        await ws.recv()
+        latencies.append((time.perf_counter() - start) * 1000)
+
+async def main():
+    latencies = []
+    await asyncio.gather(*(run_session(latencies) for _ in range(15)))
+    p95 = statistics.quantiles(latencies, n=20)[18]
+    print(f'p95 latency: {p95:.1f} ms')
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- create SQL migration for `turns` table
- implement `stt_stream` websocket endpoint
- stub websocket and router support in lightweight FastAPI
- add React hook and widget for live transcripts
- include load test script
- extend test suite with websocket test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68791ea1c2388329a74e3014f09df466