### PR TITLE
Add automated DoD checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,6 @@ jobs:
       - run: npx wait-on http://localhost:5173
       - run: npm test
         working-directory: frontend
+      - run: python scripts/load_test_script.py
       - run: docker compose down
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
           node-version: '18'
       - run: npm install
         working-directory: frontend
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install websockets
       - run: docker compose up -d
       - run: npx wait-on http://localhost:5173
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ npm test
 ```
 
 These commands mirror the steps defined in the CI workflow.
+
+To run the WebSocket load test locally install the `websockets` package and execute:
+
+```bash
+pip install websockets
+python scripts/load_test_script.py
+```

--- a/backend/app/tests/test_stt_stream.py
+++ b/backend/app/tests/test_stt_stream.py
@@ -26,3 +26,23 @@ def test_stt_stream_inserts_and_returns(tmp_path, monkeypatch):
     cur.execute("SELECT survey_id, token, question_id, role, transcript FROM turns")
     row = cur.fetchone()
     assert row == ('s1', 't1', 'q1', 'user', 'hi')
+
+
+def test_multiple_messages_create_rows(tmp_path, monkeypatch):
+    stt_stream.engine = sqlite3.connect(':memory:', check_same_thread=False)
+    stt_stream.engine.execute(
+        "CREATE TABLE turns (survey_id TEXT, token TEXT, question_id TEXT, role TEXT, audio_url TEXT, transcript TEXT, timestamp TEXT)"
+    )
+    stt_stream.UPLOAD_DIR = tmp_path
+    monkeypatch.setattr(stt_stream, 'transcribe_audio', lambda data: ('hi', 0.9))
+
+    for _ in range(3):
+        with client.websocket_connect("/stt-stream?survey_id=s1&token=t1&question_id=q1&role=user") as ws:
+            ws.send_bytes(b'abc')
+            ws.receive_json()
+
+    cur = stt_stream.engine.cursor()
+    cur.execute("SELECT COUNT(*) FROM turns")
+    count = cur.fetchone()[0]
+    assert count == 3
+    assert len(list(tmp_path.iterdir())) == 3

--- a/frontend/cypress/e2e/transcript.cy.js
+++ b/frontend/cypress/e2e/transcript.cy.js
@@ -1,0 +1,24 @@
+describe('Live transcript', () => {
+  it('renders partial transcript in real time', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        class FakeSocket {
+          constructor() {
+            this.readyState = 1
+            setTimeout(() => {
+              this.onmessage({ data: JSON.stringify({ transcript: 'hel', confidence: 0.7 }) })
+              setTimeout(() => {
+                this.onmessage({ data: JSON.stringify({ transcript: 'lo', confidence: 0.9 }) })
+              }, 50)
+            }, 50)
+          }
+          send() {}
+          close() {}
+        }
+        win.WebSocket = FakeSocket
+      }
+    })
+    cy.contains('hel')
+    cy.contains('hello')
+  })
+})

--- a/scripts/load_test_script.py
+++ b/scripts/load_test_script.py
@@ -2,7 +2,11 @@ import asyncio
 import statistics
 import time
 import sys
-import websockets
+try:
+    import websockets
+except ModuleNotFoundError:  # pragma: no cover - environment may lack dependency
+    print('websockets package not installed', file=sys.stderr)
+    sys.exit(1)
 
 URL = 'ws://localhost:8000/stt-stream?survey_id=test&token=tok&question_id=q1&role=user'
 AUDIO_CHUNK = b'0' * 32000

--- a/scripts/load_test_script.py
+++ b/scripts/load_test_script.py
@@ -1,6 +1,7 @@
 import asyncio
 import statistics
 import time
+import sys
 import websockets
 
 URL = 'ws://localhost:8000/stt-stream?survey_id=test&token=tok&question_id=q1&role=user'
@@ -18,6 +19,8 @@ async def main():
     await asyncio.gather(*(run_session(latencies) for _ in range(15)))
     p95 = statistics.quantiles(latencies, n=20)[18]
     print(f'p95 latency: {p95:.1f} ms')
+    if p95 > 300:
+        sys.exit(1)
 
 if __name__ == '__main__':
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- create Cypress test to ensure partial transcript renders
- check multiple websocket messages create rows
- exit load test script when p95 > 300ms
- run load test in CI after frontend tests

## Testing
- `pytest -q`
- `npm test --silent` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_68794ef238ac8329896b1748ea5b7e5c