### PR TITLE
Catch websocket errors in load test

### DIFF
--- a/scripts/load_test_script.py
+++ b/scripts/load_test_script.py
@@ -12,18 +12,18 @@ URL = 'ws://localhost:8000/stt-stream?survey_id=test&token=tok&question_id=q1&ro
 AUDIO_CHUNK = b'0' * 32000
 
 async def run_session(latencies):
-    start = time.perf_counter()
-    try:
-        async with websockets.connect(URL) as ws:
+    async with websockets.connect(URL) as ws:
+        start = time.perf_counter()
+        try:
             await ws.send(AUDIO_CHUNK)
             await ws.recv()
-    except websockets.exceptions.ConnectionClosedError:
-        # The server closed the connection without a proper close frame
-        # which previously caused this script to crash. We record the
-        # latency observed so far and continue.
-        pass
-    finally:
-        latencies.append((time.perf_counter() - start) * 1000)
+        except websockets.exceptions.ConnectionClosed:
+            # The server closed the connection without a proper close frame
+            # which previously caused this script to crash. We record the
+            # latency observed so far and continue.
+            pass
+        finally:
+            latencies.append((time.perf_counter() - start) * 1000)
 
 async def main():
     latencies = []

--- a/scripts/load_test_script.py
+++ b/scripts/load_test_script.py
@@ -12,10 +12,17 @@ URL = 'ws://localhost:8000/stt-stream?survey_id=test&token=tok&question_id=q1&ro
 AUDIO_CHUNK = b'0' * 32000
 
 async def run_session(latencies):
-    async with websockets.connect(URL) as ws:
-        start = time.perf_counter()
-        await ws.send(AUDIO_CHUNK)
-        await ws.recv()
+    start = time.perf_counter()
+    try:
+        async with websockets.connect(URL) as ws:
+            await ws.send(AUDIO_CHUNK)
+            await ws.recv()
+    except websockets.exceptions.ConnectionClosedError:
+        # The server closed the connection without a proper close frame
+        # which previously caused this script to crash. We record the
+        # latency observed so far and continue.
+        pass
+    finally:
         latencies.append((time.perf_counter() - start) * 1000)
 
 async def main():

--- a/scripts/load_test_script.py
+++ b/scripts/load_test_script.py
@@ -12,18 +12,19 @@ URL = 'ws://localhost:8000/stt-stream?survey_id=test&token=tok&question_id=q1&ro
 AUDIO_CHUNK = b'0' * 32000
 
 async def run_session(latencies):
-    async with websockets.connect(URL) as ws:
-        start = time.perf_counter()
-        try:
+    start = time.perf_counter()
+    try:
+        async with websockets.connect(URL) as ws:
             await ws.send(AUDIO_CHUNK)
             await ws.recv()
-        except websockets.exceptions.ConnectionClosed:
-            # The server closed the connection without a proper close frame
-            # which previously caused this script to crash. We record the
-            # latency observed so far and continue.
-            pass
-        finally:
-            latencies.append((time.perf_counter() - start) * 1000)
+    except websockets.exceptions.ConnectionClosedError:
+        # When the server abruptly terminates the WebSocket connection,
+        # ``websockets`` raises ``ConnectionClosedError`` while closing the
+        # context manager. We simply record the observed latency and continue
+        # with the next session.
+        pass
+    finally:
+        latencies.append((time.perf_counter() - start) * 1000)
 
 async def main():
     latencies = []


### PR DESCRIPTION
## Summary
- handle `ConnectionClosedError` when the websocket server does not respond with a close frame in `scripts/load_test_script.py`

## Testing
- `pytest -q`
- `python scripts/load_test_script.py` *(fails: websockets package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879879ff9f883298ef1ebf2e45037ca