### PR TITLE
Add conditional survey flow and transcript features

### DIFF
--- a/backend/app/events.py
+++ b/backend/app/events.py
@@ -1,0 +1,30 @@
+from typing import Dict, Set
+from fastapi import WebSocket, WebSocketDisconnect
+
+_subscribers: Dict[str, Set[WebSocket]] = {}
+
+async def register(survey_id: str, ws: WebSocket):
+    await ws.accept()
+    _subscribers.setdefault(survey_id, set()).add(ws)
+
+async def unregister(survey_id: str, ws: WebSocket):
+    _subscribers.get(survey_id, set()).discard(ws)
+
+async def send_event(survey_id: str, event: dict):
+    sockets = list(_subscribers.get(survey_id, []))
+    for ws in sockets:
+        try:
+            await ws.send_json(event)
+        except Exception:
+            _subscribers[survey_id].discard(ws)
+
+
+async def events_ws(ws: WebSocket, survey_id: str):
+    await register(survey_id, ws)
+    try:
+        while True:
+            await ws.receive_text()
+    except WebSocketDisconnect:
+        pass
+    finally:
+        await unregister(survey_id, ws)

--- a/backend/app/flow_engine.py
+++ b/backend/app/flow_engine.py
@@ -1,0 +1,130 @@
+import ast
+from typing import Any, Dict, Optional
+
+
+class SafeEvaluator:
+    ALLOWED_OPERATORS = {
+        ast.Gt: lambda a, b: a > b,
+        ast.Lt: lambda a, b: a < b,
+        ast.Eq: lambda a, b: a == b,
+        ast.NotEq: lambda a, b: a != b,
+        ast.GtE: lambda a, b: a >= b,
+        ast.LtE: lambda a, b: a <= b,
+    }
+
+    ALLOWED_NODES = (
+        ast.Expression,
+        ast.Compare,
+        ast.Name,
+        ast.Load,
+        ast.Constant,
+        ast.BoolOp,
+        ast.And,
+        ast.Or,
+    )
+
+    def eval(self, expr: str, context: Dict[str, Any]) -> Any:
+        tree = ast.parse(expr, mode="eval")
+        return self._eval_node(tree.body, context)
+
+    def _eval_node(self, node: ast.AST, ctx: Dict[str, Any]):
+        if isinstance(node, ast.BoolOp):
+            if isinstance(node.op, ast.And):
+                return all(self._eval_node(v, ctx) for v in node.values)
+            elif isinstance(node.op, ast.Or):
+                return any(self._eval_node(v, ctx) for v in node.values)
+            else:
+                raise ValueError("Unsupported boolean operator")
+        if isinstance(node, ast.Compare):
+            left = self._eval_node(node.left, ctx)
+            result = True
+            for op, comp in zip(node.ops, node.comparators):
+                right = self._eval_node(comp, ctx)
+                op_func = self.ALLOWED_OPERATORS.get(type(op))
+                if op_func is None:
+                    raise ValueError("Operator not allowed")
+                result = result and op_func(left, right)
+                left = right
+            return result
+        if isinstance(node, ast.Name):
+            if node.id not in ctx:
+                raise ValueError(f"Unknown variable {node.id}")
+            return ctx[node.id]
+        if isinstance(node, ast.Constant):
+            return node.value
+        raise ValueError("Unsupported expression element")
+
+
+eval_safe = SafeEvaluator().eval
+
+
+class FlowEngine:
+    def __init__(self, survey: Dict[str, Any]):
+        self.questions = survey.get("questions", [])
+        self.index_map = {q["id"]: i for i, q in enumerate(self.questions)}
+
+    def _get_question(self, qid: str) -> Optional[Dict[str, Any]]:
+        for q in self.questions:
+            if q["id"] == qid:
+                return q
+        return None
+
+    def next_question(self, current_id: str, answers: Dict[str, Any]) -> Optional[str]:
+        current = self._get_question(current_id)
+        if not current:
+            return None
+        expr = current.get("followup_if")
+        follow_id = current.get("followup_id")
+        if expr and follow_id:
+            ctx = {
+                "answer": answers.get(current_id),
+                "answers": answers,
+            }
+            try:
+                if bool(eval_safe(expr, ctx)):
+                    return follow_id
+            except Exception:
+                pass
+        idx = self.index_map.get(current_id, -1)
+        if idx >= 0 and idx + 1 < len(self.questions):
+            return self.questions[idx + 1]["id"]
+        return None
+
+import json
+from pathlib import Path
+
+TRANSCRIPTS_DIR = Path("transcripts")
+TRANSCRIPTS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def build_transcript(survey_id: str, token: str, db_engine) -> Path:
+    cur = db_engine.cursor()
+    cur.execute(
+        "SELECT question_id, role, transcript, audio_url, timestamp FROM turns WHERE survey_id=? AND token=? ORDER BY timestamp",
+        (survey_id, token),
+    )
+    rows = [
+        {
+            "question_id": q,
+            "role": r,
+            "transcript": t,
+            "audio_url": u,
+            "timestamp": ts,
+        }
+        for q, r, t, u, ts in cur.fetchall()
+    ]
+    data = {"survey_id": survey_id, "turns": rows}
+    path = TRANSCRIPTS_DIR / f"{survey_id}_{token}.json"
+    with path.open("w") as f:
+        json.dump(data, f)
+    return path
+
+
+def load_or_build_transcript(survey_id: str, token: str, db_engine) -> dict:
+    path = TRANSCRIPTS_DIR / f"{survey_id}_{token}.json"
+    if path.is_file():
+        with path.open() as f:
+            return json.load(f)
+    build_transcript(survey_id, token, db_engine)
+    with path.open() as f:
+        return json.load(f)

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,0 +1,1 @@
+surveys_storage = []

--- a/backend/app/tests/test_flow_engine.py
+++ b/backend/app/tests/test_flow_engine.py
@@ -1,0 +1,38 @@
+from app.flow_engine import FlowEngine
+
+
+def test_followup_jump():
+    survey = {
+        "questions": [
+            {"id": "q1", "type": "text", "text": "A", "followup_id": "q3", "followup_if": "answer > 5"},
+            {"id": "q2", "type": "text", "text": "B"},
+            {"id": "q3", "type": "text", "text": "C"},
+        ]
+    }
+    engine = FlowEngine(survey)
+    answers = {"q1": 10}
+    assert engine.next_question("q1", answers) == "q3"
+
+
+def test_followup_none():
+    survey = {
+        "questions": [
+            {"id": "q1", "type": "text", "text": "A", "followup_id": "q3", "followup_if": "answer > 5"},
+            {"id": "q2", "type": "text", "text": "B"},
+            {"id": "q3", "type": "text", "text": "C"},
+        ]
+    }
+    engine = FlowEngine(survey)
+    answers = {"q1": 2}
+    assert engine.next_question("q1", answers) == "q2"
+
+
+def test_end_of_survey():
+    survey = {
+        "questions": [
+            {"id": "q1", "type": "text", "text": "A"},
+        ]
+    }
+    engine = FlowEngine(survey)
+    answers = {"q1": "hi"}
+    assert engine.next_question("q1", answers) is None

--- a/backend/app/tests/test_transcript_endpoint.py
+++ b/backend/app/tests/test_transcript_endpoint.py
@@ -1,0 +1,32 @@
+import sqlite3
+from fastapi.testclient import TestClient
+from app.main import app
+from app import stt_stream
+from app import flow_engine
+
+client = TestClient(app)
+
+
+def setup_test_env(tmp_path):
+    stt_stream.engine = sqlite3.connect(':memory:', check_same_thread=False)
+    stt_stream.engine.execute(
+        "CREATE TABLE turns (survey_id TEXT, token TEXT, question_id TEXT, role TEXT, audio_url TEXT, transcript TEXT, timestamp TEXT)"
+    )
+    flow_engine.TRANSCRIPTS_DIR = tmp_path
+
+
+def test_transcript_generation(tmp_path):
+    setup_test_env(tmp_path)
+    cur = stt_stream.engine.cursor()
+    cur.execute(
+        "INSERT INTO turns (survey_id, token, question_id, role, audio_url, transcript, timestamp) VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
+        ("s1", "t1", "q1", "user", "file.wav", "hello"),
+    )
+    stt_stream.engine.commit()
+
+    response = client.get("/transcript/s1/t1")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["survey_id"] == "s1"
+    assert len(data["turns"]) == 1
+    assert data["turns"][0]["transcript"] == "hello"

--- a/examples/transcript.json
+++ b/examples/transcript.json
@@ -1,0 +1,12 @@
+{
+  "survey_id": "demo",
+  "turns": [
+    {
+      "question_id": "q1",
+      "role": "user",
+      "transcript": "Hello",
+      "audio_url": "uploads/123.wav",
+      "timestamp": "2024-01-01T00:00:00"
+    }
+  ]
+}

--- a/fastapi/__init__.py
+++ b/fastapi/__init__.py
@@ -25,6 +25,12 @@ class FastAPI:
             return func
         return decorator
 
+    def get(self, path):
+        def decorator(func):
+            self.routes[("get", path)] = func
+            return func
+        return decorator
+
     def websocket(self, path):
         def decorator(func):
             self.routes[("websocket", path)] = func

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,25 @@
+import { useState } from 'react'
 import SurveyUploader from './components/SurveyUploader'
 import LiveTranscript from './components/LiveTranscript'
+import DownloadTranscriptButton from './components/DownloadTranscriptButton'
+import SurveyEventsListener from './components/SurveyEventsListener'
 import useSttStream from './hooks/useSttStream'
 
 export default function App() {
   const stt = useSttStream({ surveyId: 'demo', token: 'demo', questionId: 'q1', role: 'user' })
+  const [completed, setCompleted] = useState(false)
 
   return (
     <div className="container mx-auto space-y-4">
       <h1 className="text-2xl font-bold mb-4">Launch Survey</h1>
       <SurveyUploader />
       <LiveTranscript transcript={stt.transcript} confirmed={stt.confirmed} />
+      {completed && (
+        <DownloadTranscriptButton surveyId="demo" token="demo" />
+      )}
+      <SurveyEventsListener surveyId="demo" onEvent={(e) => {
+        if (e.type === 'survey_completed') setCompleted(true)
+      }} />
     </div>
   )
 }

--- a/frontend/src/components/DownloadTranscriptButton.jsx
+++ b/frontend/src/components/DownloadTranscriptButton.jsx
@@ -1,0 +1,9 @@
+export default function DownloadTranscriptButton({ surveyId, token }) {
+  const base = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+  const url = `${base}/transcript/${surveyId}/${token}`
+  return (
+    <a href={url} className="px-4 py-2 bg-green-600 text-white rounded" download>
+      Download transcript
+    </a>
+  )
+}

--- a/frontend/src/components/SurveyEventsListener.jsx
+++ b/frontend/src/components/SurveyEventsListener.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+export default function SurveyEventsListener({ surveyId, onEvent }) {
+  useEffect(() => {
+    const base = import.meta.env.VITE_API_URL || 'ws://localhost:8000'
+    const ws = new WebSocket(`${base.replace('http', 'ws')}/events/${surveyId}`)
+    ws.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data)
+        if (onEvent) onEvent(data)
+      } catch {}
+    }
+    return () => ws.close()
+  }, [surveyId, onEvent])
+
+  return null
+}


### PR DESCRIPTION
## Summary
- implement conditional FlowEngine with safe expression evaluation
- add transcript building and event notifications
- expose websocket events and transcript endpoint
- support GET routes in minimal FastAPI and TestClient
- add frontend components for event listening and transcript download
- include example transcript JSON
- add unit tests for flow engine and transcript endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68799049a4588329b3c94c3d6acebf74